### PR TITLE
Feat/index all manifests

### DIFF
--- a/README-Artifact-Search.md
+++ b/README-Artifact-Search.md
@@ -4,7 +4,7 @@ This version of Zot has been modified to support enhanced Artifact search and ma
 
 ## Overview
 
-Artifacts pushed to the registry with the statement mediatype ("application/vnd.oci.statement.v1+json") are indexed and made searchable with graphql.
+Artifacts pushed to the registry with the statement mediatype ("application/vnd.uor.statement.v1+json") are indexed and made searchable with graphql.
 
 Statements are written as semantic triples. Each element of a Statement triple contains a Resource Type and the resource being described. The Resource Type contains an OCI Reference to a Resource type definition which contains the schema and interface information of the referenced resource in the statement. A resource requires a type definition for a client to understand how to interact with it. 
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -64,7 +64,7 @@ func (*ObjectStorage) GetStatementDescriptor(repo string, digest godigest.Digest
 }
 
 // MarkStatement implements types.ImageStore.
-func (*ObjectStorage) MarkStatement(repo string, descriptor ispec.Descriptor, eclient *ent.Client) error {
+func (*ObjectStorage) AddToIndex(repo string, descriptor ispec.Descriptor, manifest ispec.Manifest, eclient *ent.Client) error {
 	panic("unimplemented")
 }
 

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -53,7 +53,7 @@ type ImageStore interface { //nolint:interfacebloat
 	RunDedupeBlobs(interval time.Duration, sch *scheduler.Scheduler)
 	RunDedupeForDigest(digest godigest.Digest, dedupe bool, duplicateBlobs []string) error
 	GetNextDigestWithBlobPaths(lastDigests []godigest.Digest) (godigest.Digest, []string, error)
-	MarkStatement(repo string, descriptor ispec.Descriptor, eclient *ent.Client) error
+	AddToIndex(repo string, descriptor ispec.Descriptor, manifest ispec.Manifest, eclient *ent.Client) error
 	GetStatementDescriptor(repo string, digest godigest.Digest) ([]byte, error)
 	InitDatabase() (*ent.Client, error)
 }

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -52,7 +52,7 @@ type MockedImageStore struct {
 	RunDedupeBlobsFn             func(interval time.Duration, sch *scheduler.Scheduler)
 	RunDedupeForDigestFn         func(digest godigest.Digest, dedupe bool, duplicateBlobs []string) error
 	GetNextDigestWithBlobPathsFn func(lastDigests []godigest.Digest) (godigest.Digest, []string, error)
-	MarkStatementfn              func(repo string, descriptor ispec.Descriptor, eclient *ent.Client) error
+	AddToIndexfn                 func(repo string, descriptor ispec.Descriptor, manifest ispec.Manifest, eclient *ent.Client) error
 	GetStatementDescriptorfn     func(repo string, digest godigest.Digest) ([]byte, error)
 	InitDatabasefn               func() (*ent.Client, error)
 }
@@ -66,7 +66,7 @@ func (MockedImageStore) GetStatementDescriptor(repo string, digest godigest.Dige
 	return nil, nil
 }
 
-func (is MockedImageStore) MarkStatement(repo string, descriptor ispec.Descriptor, eclient *ent.Client) error {
+func (is MockedImageStore) AddToIndex(repo string, descriptor ispec.Descriptor, manifest ispec.Manifest, eclient *ent.Client) error {
 	return nil
 }
 


### PR DESCRIPTION
Closes #1 

Continuing in the spirit of my hack prototyping of Zot, I've implemented the indexing of OCI manifests, albeit not perfectly. 

Scenario1: 
- Client: "return all oci images matching x"
- Server: "21 records {"manifest descriptor", namespace}

Scenario2:
- Client: Which images and artifacts are affected by CVE-123?
- Server: These 21 images and/or artifacts by manifest/blob descriptor/

Target behavior:

the endpoint provides backwards compatibility with existing oci manifests by automatically indexing them as:
- manifest config descriptor = object
- manifest ( minus manifest config and layer/subject descriptors ) = predicate
- layers/subjects = subject 

Now a client can reliably query for any value of any manifest (ideally/aspirational)  